### PR TITLE
fix: debug mode not being able to be set to False

### DIFF
--- a/litestar_granian/cli.py
+++ b/litestar_granian/cli.py
@@ -231,7 +231,7 @@ def run_command(
     from litestar.cli.commands.core import _server_lifespan
 
     loops.get("auto")
-    if debug is not None:
+    if debug:
         app.debug = True
         os.environ["LITESTAR_DEBUG"] = "1"
     if pdb:


### PR DESCRIPTION
I noticed that when I tried to set LITESTAR_DEBUG to a Falsy value it was always set to True. 

This PR fixes that. Could we release this as well ? Thanks ! 