### PR TITLE
fix: multi process fork issue on windows

### DIFF
--- a/litestar_granian/cli.py
+++ b/litestar_granian/cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import multiprocessing
 import os
-import platform
 import subprocess  # noqa: S404
 import sys
 from dataclasses import fields
@@ -346,7 +345,6 @@ def run_command(
     functions with the name ``create_app`` are considered, or functions that are annotated as returning a ``Litestar``
     instance.
     """
-    _set_multiprocessing_start_method()
 
     loops.get("auto")
     if reload:
@@ -466,12 +464,6 @@ def run_command(
                 ssl_keyfile_password=ssl_keyfile_password,
                 host=host,
             )
-
-
-def _set_multiprocessing_start_method() -> None:
-    # this is currently required because the latest litestar uses a QueueListener logging handler
-    if platform.system() in {"Darwin", "Windows"}:
-        multiprocessing.set_start_method("fork", force=True)
 
 
 def _run_granian(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,14 +191,3 @@ def app_file_content(app_file_content_: tuple[str, str]) -> str:
 @pytest.fixture
 def app_file_app_name(app_file_content_: tuple[str, str]) -> str:
     return cast("str", operator.itemgetter(1)(app_file_content_))
-
-
-def _no_op() -> None:
-    return None
-
-
-@pytest.fixture(autouse=True)
-def mock_multiprocessing_set(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-    if os.getenv("GITHUB_ACTIONS") == "true" and sys.platform == "win32":
-        monkeypatch.setattr(cli, "_set_multiprocessing_start_method", _no_op)
-    yield


### PR DESCRIPTION
multi process fork issue on windows causing `ValueError: cannot find context for 'fork'`